### PR TITLE
chore(run_inference_area): remove unused `CLIENT_ID`/`CLIENT_SECRET`

### DIFF
--- a/demo/run_inference_area.ipynb
+++ b/demo/run_inference_area.ipynb
@@ -60,9 +60,7 @@
     "\n",
     "from google.colab import userdata\n",
     "\n",
-    "os.environ[\"MAPBOX_TOKEN\"] = userdata.get(\"MAPBOX_TOKEN\")\n",
-    "os.environ[\"OSM_CLIENT_ID\"] = userdata.get(\"OSM_CLIENT_ID\")\n",
-    "os.environ[\"OSM_CLIENT_SECRET\"] = userdata.get(\"OSM_CLIENT_SECRET\")"
+    "os.environ[\"MAPBOX_TOKEN\"] = userdata.get(\"MAPBOX_TOKEN\")"
    ]
   },
   {


### PR DESCRIPTION
# What's changing

Since #7, there is no longer a need to configure a OAuth client & the secrets. So we can remove this from the `run_inference_area` notebook

# How to test it

_-_

# Additional notes for reviewers

_-_

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] ~~Added some tests for any new functionality~~
- [x] ~~Updated the documentation (both comments in code and under `/docs`)~~
