### PR TITLE
fix(coordinates): incorrect bbox used in the southern hemisphere

### DIFF
--- a/src/osm_ai_helper/utils/coordinates.py
+++ b/src/osm_ai_helper/utils/coordinates.py
@@ -38,7 +38,7 @@ def pixel_col_row_to_meters_col_row(pixel_col, pixel_row, zoom):
     if pixel_col < half_size:
         meter_col *= -1
     if pixel_row > half_size:
-        meter_col *= -1
+        meter_row *= -1
     return meter_col, meter_row
 
 

--- a/tests/unit/test_coordinates.py
+++ b/tests/unit/test_coordinates.py
@@ -1,0 +1,30 @@
+
+from osm_ai_helper.utils.coordinates import (
+  lat_lon_to_tile_col_row,
+  pixel_col_row_to_meters_col_row,
+  meters_col_row_to_lat_lon,
+  TILE_SIZE
+)
+
+test_cases = [
+    (-36.824380, 174.805511),
+    (50.921286, 6.959694),
+    (-16.504525, -68.154695),
+    (37.352957, -121.926294),
+    (0, 0)
+]
+
+for (lat, lon) in test_cases:
+    for zoom in [18, 21]: # test multiple zoom levels; this should not make a difference
+      x, y = lat_lon_to_tile_col_row(lat, lon, zoom)
+
+      x_centre = (x * TILE_SIZE) + TILE_SIZE / 2
+      y_center = (y * TILE_SIZE) + TILE_SIZE / 2
+      x_metres, y_metres = pixel_col_row_to_meters_col_row(x_centre, y_center, zoom)
+
+      (lat_center, lon_center) = meters_col_row_to_lat_lon(x_metres, y_metres)
+
+      assert abs(lat - lat_center) < 0.001
+      assert abs(lon - lon_center) < 0.001
+
+print('coordinate tests passed')


### PR DESCRIPTION
# What's changing

This project currently does not work in the southern hemisphere (where `latitude < 0`). This appears to be because of a trivial bug. 

Added some unit tests to confirm that coordinates can be converted from lat/lon to x/y/z and back, for all 4 hemispheres. 

# How to test it

Steps to test the changes:

1. Run the new unit tests
2. or try run the tool normally 

# Additional notes for reviewers

_-_

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] ~~Updated the documentation (both comments in code and under `/docs`)~~
