### PR TITLE
chore(coordinates): replace magic numbers with `TILE_SIZE`

### DIFF
--- a/src/osm_ai_helper/utils/inference.py
+++ b/src/osm_ai_helper/utils/inference.py
@@ -44,8 +44,8 @@ def split_area_into_lat_lon_centers(
     lat_lon_centers = []
     for col in range(left + margin, right + 1, (margin * 2) + 1):
         for row in range(top + margin, bottom + 1, (margin * 2) + 1):
-            pixel_col_center = (col * 512) + 256
-            pixel_row_center = (row * 512) + 256
+            pixel_col_center = (col * TILE_SIZE) + TILE_SIZE / 2
+            pixel_row_center = (row * TILE_SIZE) + TILE_SIZE / 2
             meters_col_center, meters_row_center = pixel_col_row_to_meters_col_row(
                 pixel_col_center, pixel_row_center, zoom
             )
@@ -188,8 +188,8 @@ def predict_tile_batch(
             if bbox_pad > 0:
                 bbox_int[0] = max(0, bbox_int[0] - bbox_pad)
                 bbox_int[1] = max(0, bbox_int[1] - bbox_pad)
-                bbox_int[2] = min(512, bbox_int[2] + bbox_pad)
-                bbox_int[3] = min(512, bbox_int[3] + bbox_pad)
+                bbox_int[2] = min(TILE_SIZE, bbox_int[2] + bbox_pad)
+                bbox_int[3] = min(TILE_SIZE, bbox_int[3] + bbox_pad)
 
             masks, *_ = sam_predictor.predict(
                 box=[bbox_int],


### PR DESCRIPTION
# What's changing

If you want to use a different tileserver, simply changing `TILE_SIZE` is not sufficient. There are some other hardcoded constants that need to be changed.

This PR replaces those other magic numbers with the `TILE_SIZE` constant.


# How to test it

Steps to test the changes:

1. change `TILE_SIZE` to a custom value & use a different tileserver
2. notice how the maths still works

# Additional notes for reviewers


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] ~~Updated the documentation (both comments in code and under `/docs`)~~
