### PR TITLE
Update osm.py to use new jsonv2 format. "json" no longer seems to be …

### DIFF
--- a/src/osm_ai_helper/utils/osm.py
+++ b/src/osm_ai_helper/utils/osm.py
@@ -16,7 +16,7 @@ def get_area(area_name: str) -> dict:
         dict: The area found.
     """
     response = requests.get(
-        f"https://nominatim.openstreetmap.org/search?q={area_name}&format=json",
+        f"https://nominatim.openstreetmap.org/search?q={area_name}&format=jsonv2",
         headers={"User-Agent": "Mozilla/5.0"},
     )
     response.raise_for_status()


### PR DESCRIPTION
…supported

# What's changing

OSM nominatim API no longer supports "json" format in request URL. Must be "jsonv2"



# How to test it

Steps to test the changes:

TRAIN_AREA = "Galicia"
VAL_AREA = "Viana do Castelo"
SELECTOR = "leisure=swimming_pool"
DISCARD = {"location": "indoor"}
CLASS_NAME = "swimming_pool"

download_osm(
    area=TRAIN_AREA,
    output_dir="datasets",
    selector=SELECTOR,
    discard=DISCARD,
)

# I already...

- [ x] Tested the changes in a working environment to ensure they work as expected
